### PR TITLE
feat: status 로직 작성,  score 로직 작성, security_vitals&web_vitals entity 작성

### DIFF
--- a/src/main/java/com/test/webtest/domain/airecommendation/service/AiRecommendationService.java
+++ b/src/main/java/com/test/webtest/domain/airecommendation/service/AiRecommendationService.java
@@ -1,4 +1,7 @@
 package com.test.webtest.domain.airecommendation.service;
 
+import java.util.UUID;
+
 public interface AiRecommendationService {
+    void invokeAsync(UUID testId);
 }

--- a/src/main/java/com/test/webtest/domain/airecommendation/service/AiRecommendationServiceImpl.java
+++ b/src/main/java/com/test/webtest/domain/airecommendation/service/AiRecommendationServiceImpl.java
@@ -1,4 +1,21 @@
 package com.test.webtest.domain.airecommendation.service;
 
-public class AiRecommendationServiceImpl {
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AiRecommendationServiceImpl implements AiRecommendationService{
+    @Override
+    @Async("logicExecutor")
+    public void invokeAsync(UUID testId) {
+        log.info("[AI] invoke recommendations for testId={}", testId);
+
+        // 프롬프트 생성 및 외부 AI 호출
+    }
 }

--- a/src/main/java/com/test/webtest/domain/ip/controller/IpController.java
+++ b/src/main/java/com/test/webtest/domain/ip/controller/IpController.java
@@ -1,4 +1,0 @@
-package com.test.webtest.domain.ip.controller;
-
-public class IpController {
-}

--- a/src/main/java/com/test/webtest/domain/ip/entity/IpEntity.java
+++ b/src/main/java/com/test/webtest/domain/ip/entity/IpEntity.java
@@ -1,4 +1,0 @@
-package com.test.webtest.domain.ip.entity;
-
-public class IpEntity {
-}

--- a/src/main/java/com/test/webtest/domain/ip/repository/IpRepository.java
+++ b/src/main/java/com/test/webtest/domain/ip/repository/IpRepository.java
@@ -1,4 +1,0 @@
-package com.test.webtest.domain.ip.repository;
-
-public class IpRepository {
-}

--- a/src/main/java/com/test/webtest/domain/logicstatus/entity/LogicStatusEntity.java
+++ b/src/main/java/com/test/webtest/domain/logicstatus/entity/LogicStatusEntity.java
@@ -1,4 +1,54 @@
 package com.test.webtest.domain.logicstatus.entity;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "logic_status")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
 public class LogicStatusEntity {
+    @Id
+    @Column(name = "test_id", nullable = false)
+    private UUID testId;
+
+    @Column(name = "web_received", nullable = false)
+    private boolean webReceived;
+
+    @Column(name = "sec_received", nullable = false)
+    private boolean secReceived;
+
+    @Column(name = "scores_ready", nullable = false)
+    private boolean scoresReady;
+
+    @Column(name = "ai_triggered", nullable = false)
+    private boolean aiTriggered;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    public static LogicStatusEntity create(UUID testId) {
+        return LogicStatusEntity.builder()
+                .testId(testId)
+                .webReceived(false)
+                .secReceived(false)
+                .scoresReady(false)
+                .aiTriggered(false)
+                .build();
+    }
 }

--- a/src/main/java/com/test/webtest/domain/logicstatus/repository/LogicStatusRepository.java
+++ b/src/main/java/com/test/webtest/domain/logicstatus/repository/LogicStatusRepository.java
@@ -1,4 +1,57 @@
 package com.test.webtest.domain.logicstatus.repository;
 
-public class LogicStatusRepository {
+import com.test.webtest.domain.logicstatus.entity.LogicStatusEntity;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import java.util.*;
+
+@Repository
+public interface LogicStatusRepository extends JpaRepository<LogicStatusEntity, UUID> {
+
+    // 1) 웹 플래그 ON
+    @Modifying
+    @Query(value = """
+        UPDATE logic_status
+           SET web_received = TRUE, updated_at = now()
+         WHERE test_id = :testId
+        RETURNING web_received, sec_received, scores_ready, ai_triggered
+        """, nativeQuery = true)
+    List<Object[]> markWebReceived(@Param("testId") UUID testId);
+
+    // 2) 보안 플래그 ON
+    @Modifying
+    @Query(value = """
+        UPDATE logic_status
+           SET sec_received = TRUE, updated_at = now()
+         WHERE test_id = :testId
+        RETURNING web_received, sec_received, scores_ready, ai_triggered
+        """, nativeQuery = true)
+    List<Object[]> markSecReceived(@Param("testId") UUID testId);
+
+    // 3) 점수 준비 마킹 (경합 방지)
+    @Modifying
+    @Query(value = """
+        UPDATE logic_status
+           SET scores_ready = TRUE, updated_at = now()
+         WHERE test_id = :testId
+           AND web_received = TRUE
+           AND sec_received = TRUE
+           AND scores_ready = FALSE
+        RETURNING scores_ready
+        """, nativeQuery = true)
+    List<Object[]> markScoresReady(@Param("testId") UUID testId);
+
+    // 4) AI 트리거 마킹 (경합 방지)
+    @Modifying
+    @Query(value = """
+        UPDATE logic_status
+           SET ai_triggered = TRUE, updated_at = now()
+         WHERE test_id = :testId
+           AND web_received = TRUE
+           AND sec_received = TRUE
+           AND ai_triggered = FALSE
+        RETURNING ai_triggered
+        """, nativeQuery = true)
+    List<Object[]> markAiTriggered(@Param("testId") UUID testId);
 }

--- a/src/main/java/com/test/webtest/domain/logicstatus/service/LogicStatusService.java
+++ b/src/main/java/com/test/webtest/domain/logicstatus/service/LogicStatusService.java
@@ -1,4 +1,0 @@
-package com.test.webtest.domain.logicstatus.service;
-
-public interface LogicStatusService {
-}

--- a/src/main/java/com/test/webtest/domain/logicstatus/service/LogicStatusServiceImpl.java
+++ b/src/main/java/com/test/webtest/domain/logicstatus/service/LogicStatusServiceImpl.java
@@ -1,4 +1,46 @@
 package com.test.webtest.domain.logicstatus.service;
 
+import com.test.webtest.domain.airecommendation.service.AiRecommendationService;
+import com.test.webtest.domain.logicstatus.repository.LogicStatusRepository;
+import com.test.webtest.domain.scores.service.ScoresService;
+import com.test.webtest.global.common.constants.Channel;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
 public class LogicStatusServiceImpl {
+    private final LogicStatusRepository repo;
+    private final ScoresService scoresService;
+    private final AiRecommendationService aiService;
+
+    @Transactional
+    public void onPartialUpdate(UUID testId, Channel channel) {
+        switch(channel) {
+            case WEB -> repo.markWebReceived(testId);
+            case SECURITY -> repo.markSecReceived(testId);
+        }
+
+        // 점수 계산 (비동기)
+        boolean scoresMarked = markScoresReadyIfEligible(testId);
+        if (scoresMarked) scoresService.calcAndSaveAsync(testId);
+
+        // Ai 호출 (비동기)
+        boolean aiMarked = markAiTriggeredIfEligible(testId);
+        if (aiMarked) aiService.invokeAsync(testId);
+    }
+
+    private boolean markScoresReadyIfEligible(UUID testId) {
+        List<Object[]> rows = repo.markScoresReady(testId);
+        return !rows.isEmpty();
+    }
+
+    private boolean markAiTriggeredIfEligible(UUID testId) {
+        List<Object[]> rows = repo.markAiTriggered(testId);
+        return !rows.isEmpty();
+    }
 }

--- a/src/main/java/com/test/webtest/domain/scores/entity/ScoresEntity.java
+++ b/src/main/java/com/test/webtest/domain/scores/entity/ScoresEntity.java
@@ -1,4 +1,76 @@
 package com.test.webtest.domain.scores.entity;
 
+import com.test.webtest.domain.test.entity.TestEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "scores")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
 public class ScoresEntity {
+    @Id
+    private UUID id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "test_id", nullable = false)
+    private TestEntity test;
+
+    @Column(name = "total", nullable = false)
+    private Integer total;        // 웹50 + 보안50
+
+    @Column(name = "lcp_score")
+    private Integer lcpScore;
+
+    @Column(name = "cls_score")
+    private Integer clsScore;
+
+    @Column(name = "inp_score")
+    private Integer inpScore;
+
+    @Column(name = "fcp_score")
+    private Integer fcpScore;
+
+    @Column(name = "tbt_score")
+    private Integer tbtScore;
+
+    @Column(name = "ttfb_score")
+    private Integer ttfbScore;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    public static ScoresEntity create(TestEntity test,
+                                      int total, Integer lcp, Integer cls, Integer inp,
+                                      Integer fcp, Integer tbt, Integer ttfb) {
+        return ScoresEntity.builder()
+                .id(UUID.randomUUID())
+                .test(test)
+                .total(total)
+                .lcpScore(lcp)
+                .clsScore(cls)
+                .inpScore(inp)
+                .fcpScore(fcp)
+                .tbtScore(tbt)
+                .ttfbScore(ttfb)
+                .build();
+    }
+
+    public void update(int total, Integer lcp, Integer cls, Integer inp,
+                       Integer fcp, Integer tbt, Integer ttfb) {
+        this.total = total;
+        this.lcpScore = lcp;
+        this.clsScore = cls;
+        this.inpScore = inp;
+        this.fcpScore = fcp;
+        this.tbtScore = tbt;
+        this.ttfbScore = ttfb;
+    }
 }

--- a/src/main/java/com/test/webtest/domain/scores/repository/ScoresRepository.java
+++ b/src/main/java/com/test/webtest/domain/scores/repository/ScoresRepository.java
@@ -1,4 +1,12 @@
 package com.test.webtest.domain.scores.repository;
 
-public class ScoresRepository {
+import com.test.webtest.domain.scores.entity.ScoresEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ScoresRepository extends JpaRepository<ScoresEntity, UUID> {
+    Optional<ScoresEntity> findByTestId(UUID testId);
+    boolean existsByTestId(UUID testId);
 }

--- a/src/main/java/com/test/webtest/domain/scores/service/ScoresService.java
+++ b/src/main/java/com/test/webtest/domain/scores/service/ScoresService.java
@@ -1,4 +1,7 @@
 package com.test.webtest.domain.scores.service;
 
+import java.util.UUID;
+
 public interface ScoresService {
+    void calcAndSaveAsync(UUID testId);
 }

--- a/src/main/java/com/test/webtest/domain/scores/service/ScoresServiceImpl.java
+++ b/src/main/java/com/test/webtest/domain/scores/service/ScoresServiceImpl.java
@@ -1,4 +1,67 @@
 package com.test.webtest.domain.scores.service;
 
-public class ScoresServiceImpl {
+import com.test.webtest.domain.scores.entity.ScoresEntity;
+import com.test.webtest.domain.scores.repository.ScoresRepository;
+import com.test.webtest.domain.securityvitals.entity.SecurityVitalsEntity;
+import com.test.webtest.domain.securityvitals.repository.SecurityVitalsRepository;
+import com.test.webtest.domain.test.entity.TestEntity;
+import com.test.webtest.domain.test.repository.TestRepository;
+import com.test.webtest.domain.webvitals.entity.WebVitalsEntity;
+import com.test.webtest.domain.webvitals.repository.WebVitalsRepository;
+import com.test.webtest.global.common.util.ScoreCalculator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ScoresServiceImpl implements ScoresService{
+
+    private final ScoresRepository scoresRepository;
+    private final WebVitalsRepository webVitalsRepository;
+    private final SecurityVitalsRepository securityVitalsRepository;
+    private final TestRepository testRepository;
+    private final ScoreCalculator scoreCalculator;
+
+    @Async("logicExecutor")
+    public void calcAndSaveAsync(UUID testId) {
+        log.info("[SCORES] Calculating scores for testId = {}", testId);
+
+        WebVitalsEntity web = webVitalsRepository.findByTestId(testId)
+                .orElse(null); // 웹 없을 수도 있음(가중치 0으로 처리)
+        SecurityVitalsEntity sec = securityVitalsRepository.findByTestId(testId)
+                .orElse(null);
+
+        // 웹 지표 100점화 {lcp, cls, inp, fcp, tbt, ttfb}
+        var webScore = scoreCalculator.toWebScores(web);
+
+        // 보안 50점화
+        int securityHalf = scoreCalculator.toSecurityHalfScore(sec);
+
+        // 총점 = 웹세부 평균 등으로 0~100 만들고 *0.5) + 보안
+        int total = scoreCalculator.totalFrom(webScore, securityHalf);
+
+        TestEntity test = testRepository.getReferenceById(testId);
+        scoresRepository.findByTestId(testId).ifPresentOrElse(
+            found -> {
+                found.update(total,
+                        webScore.lcp(), webScore.cls(), webScore.inp(),
+                        webScore.fcp(), webScore.tbt(), webScore.ttfb());
+                log.info("[SCORES] updated testId={} total={}", testId, total);
+            },
+            ()->{
+                ScoresEntity created = ScoresEntity.create(
+                        test, total,
+                        webScore.lcp(), webScore.cls(), webScore.inp(),
+                        webScore.fcp(), webScore.tbt(), webScore.ttfb()
+                );
+                scoresRepository.save(created);
+                log.info("[SCORES] inserted testId={} total={}", testId, total);
+            }
+        );
+    }
 }

--- a/src/main/java/com/test/webtest/domain/securityvitals/entity/SecurityVitalsEntity.java
+++ b/src/main/java/com/test/webtest/domain/securityvitals/entity/SecurityVitalsEntity.java
@@ -1,4 +1,177 @@
 package com.test.webtest.domain.securityvitals.entity;
 
+import com.test.webtest.domain.test.entity.TestEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "security_vitals")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
 public class SecurityVitalsEntity {
+
+    @Id
+    private UUID id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "test_id", nullable = false, unique = true)
+    private TestEntity test;
+
+    // --- 기본 헤더 플래그/값 ---
+    @Column(name = "has_csp")
+    private Boolean hasCsp;
+
+    @Column(name = "has_hsts")
+    private Boolean hasHsts;
+
+    @Column(name = "x_frame_options", length = 50)
+    private String xFrameOptions;
+
+    @Column(name = "x_content_type_options", length = 50)
+    private String xContentTypeOptions;
+
+    // --- 확장 컬럼들 ---
+    @Column(name = "referrer_policy", length = 50)
+    private String referrerPolicy;
+
+    @Column(name = "hsts_max_age")
+    private Long hstsMaxAge;
+
+    @Column(name = "hsts_include_subdomains")
+    private Boolean hstsIncludeSubdomains;
+
+    @Column(name = "hsts_preload")
+    private Boolean hstsPreload;
+
+    @Column(name = "csp_has_unsafe_inline")
+    private Boolean cspHasUnsafeInline;
+
+    @Column(name = "csp_has_unsafe_eval")
+    private Boolean cspHasUnsafeEval;
+
+    @Column(name = "csp_frame_ancestors", columnDefinition = "text")
+    private String cspFrameAncestors;
+
+    @Column(name = "cookie_secure_all")
+    private Boolean cookieSecureAll;
+
+    @Column(name = "cookie_httponly_all")
+    private Boolean cookieHttpOnlyAll;
+
+    @Column(name = "cookie_samesite_policy", length = 10)
+    private String cookieSameSitePolicy; // Strict/Lax/None/Unspecified
+
+    @Column(name = "ssl_valid")
+    private Boolean sslValid;
+
+    @Column(name = "ssl_chain_valid")
+    private Boolean sslChainValid;
+
+    @Column(name = "ssl_days_remaining")
+    private Integer sslDaysRemaining;
+
+    @Column(name = "ssl_issuer", columnDefinition = "text")
+    private String sslIssuer;
+
+    @Column(name = "ssl_subject", columnDefinition = "text")
+    private String sslSubject;
+
+    @Column(name = "csp_raw", columnDefinition = "text")
+    private String cspRaw;
+
+    @Column(name = "hsts_raw", columnDefinition = "text")
+    private String hstsRaw;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    // --- 팩토리 ---
+    public static SecurityVitalsEntity create(TestEntity test, SaveCommand c) {
+        return SecurityVitalsEntity.builder()
+                .id(UUID.randomUUID())
+                .test(test)
+                .hasCsp(c.hasCsp())
+                .hasHsts(c.hasHsts())
+                .xFrameOptions(c.xFrameOptions())
+                .xContentTypeOptions(c.xContentTypeOptions())
+                .referrerPolicy(c.referrerPolicy())
+                .hstsMaxAge(c.hstsMaxAge())
+                .hstsIncludeSubdomains(c.hstsIncludeSubdomains())
+                .hstsPreload(c.hstsPreload())
+                .cspHasUnsafeInline(c.cspHasUnsafeInline())
+                .cspHasUnsafeEval(c.cspHasUnsafeEval())
+                .cspFrameAncestors(c.cspFrameAncestors())
+                .cookieSecureAll(c.cookieSecureAll())
+                .cookieHttpOnlyAll(c.cookieHttpOnlyAll())
+                .cookieSameSitePolicy(c.cookieSameSitePolicy())
+                .sslValid(c.sslValid())
+                .sslChainValid(c.sslChainValid())
+                .sslDaysRemaining(c.sslDaysRemaining())
+                .sslIssuer(c.sslIssuer())
+                .sslSubject(c.sslSubject())
+                .cspRaw(c.cspRaw())
+                .hstsRaw(c.hstsRaw())
+                .build();
+    }
+
+    // --- 업데이트 메서드(Upsert 시 사용) ---
+    public void updateFrom(SaveCommand c) {
+        this.hasCsp = c.hasCsp();
+        this.hasHsts = c.hasHsts();
+        this.xFrameOptions = c.xFrameOptions();
+        this.xContentTypeOptions = c.xContentTypeOptions();
+        this.referrerPolicy = c.referrerPolicy();
+        this.hstsMaxAge = c.hstsMaxAge();
+        this.hstsIncludeSubdomains = c.hstsIncludeSubdomains();
+        this.hstsPreload = c.hstsPreload();
+        this.cspHasUnsafeInline = c.cspHasUnsafeInline();
+        this.cspHasUnsafeEval = c.cspHasUnsafeEval();
+        this.cspFrameAncestors = c.cspFrameAncestors();
+        this.cookieSecureAll = c.cookieSecureAll();
+        this.cookieHttpOnlyAll = c.cookieHttpOnlyAll();
+        this.cookieSameSitePolicy = c.cookieSameSitePolicy();
+        this.sslValid = c.sslValid();
+        this.sslChainValid = c.sslChainValid();
+        this.sslDaysRemaining = c.sslDaysRemaining();
+        this.sslIssuer = c.sslIssuer();
+        this.sslSubject = c.sslSubject();
+        this.cspRaw = c.cspRaw();
+        this.hstsRaw = c.hstsRaw();
+    }
+
+    /**
+     * 서비스에서 사용하기 위한 저장 커맨드(스캔 결과를 그대로 담음)
+     */
+    @Builder
+    public record SaveCommand(
+            Boolean hasCsp,
+            Boolean hasHsts,
+            String  xFrameOptions,
+            String  xContentTypeOptions,
+
+            String  referrerPolicy,
+            Long    hstsMaxAge,
+            Boolean hstsIncludeSubdomains,
+            Boolean hstsPreload,
+            Boolean cspHasUnsafeInline,
+            Boolean cspHasUnsafeEval,
+            String  cspFrameAncestors,
+            Boolean cookieSecureAll,
+            Boolean cookieHttpOnlyAll,
+            String  cookieSameSitePolicy,
+            Boolean sslValid,
+            Boolean sslChainValid,
+            Integer sslDaysRemaining,
+            String  sslIssuer,
+            String  sslSubject,
+            String  cspRaw,
+            String  hstsRaw
+    ) {}
 }

--- a/src/main/java/com/test/webtest/domain/securityvitals/repository/SecurityVitalsRepository.java
+++ b/src/main/java/com/test/webtest/domain/securityvitals/repository/SecurityVitalsRepository.java
@@ -1,4 +1,12 @@
 package com.test.webtest.domain.securityvitals.repository;
 
-public class SecurityVitalsRepository {
+import com.test.webtest.domain.securityvitals.entity.SecurityVitalsEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SecurityVitalsRepository extends JpaRepository<SecurityVitalsEntity, UUID> {
+    Optional<SecurityVitalsEntity> findByTestId(UUID testID);
+    boolean existsByTestId(UUID testId);
 }

--- a/src/main/java/com/test/webtest/domain/securityvitals/service/SecurityVitalsService.java
+++ b/src/main/java/com/test/webtest/domain/securityvitals/service/SecurityVitalsService.java
@@ -1,4 +1,7 @@
 package com.test.webtest.domain.securityvitals.service;
 
+import java.util.UUID;
+
 public interface SecurityVitalsService {
+    void scanAndSave(UUID testId);
 }

--- a/src/main/java/com/test/webtest/domain/securityvitals/service/SecurityVitalsServiceImpl.java
+++ b/src/main/java/com/test/webtest/domain/securityvitals/service/SecurityVitalsServiceImpl.java
@@ -1,4 +1,74 @@
 package com.test.webtest.domain.securityvitals.service;
 
-public class SecurityVitalsServiceImpl {
+import com.test.webtest.domain.logicstatus.service.LogicStatusServiceImpl;
+import com.test.webtest.domain.securityvitals.entity.SecurityVitalsEntity;
+import com.test.webtest.domain.securityvitals.entity.SecurityVitalsEntity.SaveCommand;
+import com.test.webtest.domain.securityvitals.repository.SecurityVitalsRepository;
+import com.test.webtest.domain.test.entity.TestEntity;
+import com.test.webtest.domain.test.repository.TestRepository;
+import com.test.webtest.global.common.constants.Channel;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SecurityVitalsServiceImpl implements SecurityVitalsService {
+    private final TestRepository testRepository;
+    private final SecurityVitalsRepository securityVitalsRepository;
+    private final LogicStatusServiceImpl logicStatusService;
+
+    @Override
+    @Transactional
+    public void scanAndSave(UUID testId) {
+        TestEntity test = testRepository.getReferenceById(testId);
+
+        SaveCommand result = SaveCommand.builder()
+                .hasCsp(true)
+                .hasHsts(true)
+                .xFrameOptions("SAMEORIGIN")
+                .xContentTypeOptions("nosniff")
+                .referrerPolicy("no-referrer-when-downgrade")
+                .hstsMaxAge(31536000L)
+                .hstsIncludeSubdomains(true)
+                .hstsPreload(false)
+                .cspHasUnsafeInline(false)
+                .cspHasUnsafeEval(false)
+                .cspFrameAncestors("'self'")
+                .cookieSecureAll(true)
+                .cookieHttpOnlyAll(true)
+                .cookieSameSitePolicy("Lax")
+                .sslValid(true)
+                .sslChainValid(true)
+                .sslDaysRemaining(120)
+                .sslIssuer("Let's Encrypt")
+                .sslSubject("CN=example.com")
+                .cspRaw("default-src 'self'; img-src https: data:;")
+                .hstsRaw("max-age=31536000; includeSubDomains")
+                .build();
+
+        securityVitalsRepository.findByTestId(testId).ifPresentOrElse(
+                found -> {
+                    found.updateFrom(result);
+                    log.info("[SEC] updated testId={}", testId);
+                },
+                () -> {
+                    SecurityVitalsEntity created = SecurityVitalsEntity.create(test, result);
+                    securityVitalsRepository.save(created);
+                    log.info("[SEC] inserted testId={}", testId);
+                }
+        );
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override public void afterCommit() {
+                logicStatusService.onPartialUpdate(testId, Channel.SECURITY);
+            }
+        });
+    }
 }

--- a/src/main/java/com/test/webtest/domain/test/entity/TestEntity.java
+++ b/src/main/java/com/test/webtest/domain/test/entity/TestEntity.java
@@ -14,6 +14,8 @@ import java.util.UUID;
 @Table(name = "tests")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
 public class TestEntity {
     @Id
     private UUID id;
@@ -31,17 +33,9 @@ public class TestEntity {
     @CreationTimestamp
     private Instant createdAt;
 
-    @Builder(builderMethodName = "internalBuilder")
-    private TestEntity(UUID id, String url, String domainName, StatusType status) {
-        this.id = id;
-        this.url = url;
-        this.domainName = domainName;
-        this.status = status;
-    }
-
     // 엔티티 생성 팩토리 메서드
     public static TestEntity create(String url){
-        return internalBuilder()
+        return TestEntity.builder()
             .id(UUID.randomUUID())
             .url(url)
             .domainName(UrlNormalizer.extractDomain(url))

--- a/src/main/java/com/test/webtest/domain/webvitals/entity/WebVitalsEntity.java
+++ b/src/main/java/com/test/webtest/domain/webvitals/entity/WebVitalsEntity.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 @Builder(access = AccessLevel.PRIVATE)
 public class WebVitalsEntity {
     @Id
-    private UUID testId;
+    private UUID id;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "test_id", unique = true, nullable = false)
@@ -59,6 +59,7 @@ public class WebVitalsEntity {
         validateMetricValue(ttfb, "TTFB");
 
         return WebVitalsEntity.builder()
+                .id(UUID.randomUUID())
                 .test(test)  // @MapsId를 사용하므로 test만 설정하면 testId는 자동으로 매핑됨
                 .lcp(lcp)
                 .cls(cls)

--- a/src/main/java/com/test/webtest/domain/webvitals/service/WebVitalsService.java
+++ b/src/main/java/com/test/webtest/domain/webvitals/service/WebVitalsService.java
@@ -1,4 +1,11 @@
 package com.test.webtest.domain.webvitals.service;
 
+import java.util.UUID;
+
 public interface WebVitalsService {
+    void saveWebVitals(UUID testId, WebVitalsSaveCommand command);
+
+    record WebVitalsSaveCommand(
+            Double lcp, Double fid, Double cls, Double fcp, Double ttfb, Double inp, Double tbt
+    ){}
 }

--- a/src/main/java/com/test/webtest/domain/webvitals/service/WebVitalsServiceImpl.java
+++ b/src/main/java/com/test/webtest/domain/webvitals/service/WebVitalsServiceImpl.java
@@ -1,4 +1,42 @@
 package com.test.webtest.domain.webvitals.service;
 
-public class WebVitalsServiceImpl {
+import com.test.webtest.domain.logicstatus.service.LogicStatusServiceImpl;
+import com.test.webtest.domain.test.entity.TestEntity;
+import com.test.webtest.domain.test.repository.TestRepository;
+import com.test.webtest.domain.webvitals.entity.WebVitalsEntity;
+import com.test.webtest.domain.webvitals.repository.WebVitalsRepository;
+import com.test.webtest.global.common.constants.Channel;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class WebVitalsServiceImpl implements WebVitalsService{
+    private final WebVitalsRepository webVitalsRepository;
+    private final TestRepository testRepository;
+    private final LogicStatusServiceImpl logicStatusService;
+
+    @Override
+    @Transactional
+    public void saveWebVitals(UUID testId, WebVitalsSaveCommand cmd) {
+        TestEntity test = testRepository.getReferenceById(testId);
+
+        WebVitalsEntity entity = WebVitalsEntity.create(
+                test, cmd.lcp(), cmd.cls(), cmd.inp(), cmd.fcp(), cmd.tbt(), cmd.ttfb()
+        );
+
+        webVitalsRepository.save(entity);
+
+        // 커밋 이후 status 호출
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override public void afterCommit() {
+                logicStatusService.onPartialUpdate(testId, Channel.WEB);
+            }
+        });
+    }
 }

--- a/src/main/java/com/test/webtest/global/common/constants/Channel.java
+++ b/src/main/java/com/test/webtest/global/common/constants/Channel.java
@@ -1,3 +1,3 @@
 package com.test.webtest.global.common.constants;
 
-public enum PriorityType {PERFORMANCE, SECURITY}
+public enum Channel {WEB, SECURITY}

--- a/src/main/java/com/test/webtest/global/common/util/ScoreCalculator.java
+++ b/src/main/java/com/test/webtest/global/common/util/ScoreCalculator.java
@@ -1,4 +1,48 @@
 package com.test.webtest.global.common.util;
 
+import com.test.webtest.domain.securityvitals.entity.SecurityVitalsEntity;
+import com.test.webtest.domain.webvitals.entity.WebVitalsEntity;
+import org.springframework.stereotype.Component;
+
+@Component
 public class ScoreCalculator {
+
+    /**
+     * 웹 성능 지표(LCP, CLS, INP 등)를 100점화하여 반환한다.
+     */
+    public WebScores toWebScores(WebVitalsEntity web) {
+        //실제 계산 로직 추가
+        return new WebScores(80, 90, 85, 88, 70, 75); // 임시 값
+    }
+
+    /**
+     * 보안 지표를 50점화하여 반환한다. (내부에서 0~100 → 0~50 환산)
+     */
+    public int toSecurityHalfScore(SecurityVitalsEntity sec) {
+        // 실제 계산 로직 추가
+        return 40; // 임시 값
+    }
+
+    /**
+     * 총점을 계산한다. (웹 50 + 보안 50 구조)
+     */
+    public int totalFrom(WebScores webScores, int securityHalf) {
+        // 실제 계산 로직 추가
+        int webAvg = (webScores.lcp + webScores.cls + webScores.inp +
+                webScores.fcp + webScores.tbt + webScores.ttfb) / 6;
+        int webHalf = (int) (webAvg * 0.5);
+        return Math.min(100, webHalf + securityHalf);
+    }
+
+    /**
+     * 웹 점수 묶음 구조체 (Java 17 record)
+     */
+    public record WebScores(
+            int lcp,
+            int cls,
+            int inp,
+            int fcp,
+            int tbt,
+            int ttfb
+    ) {}
 }

--- a/src/main/java/com/test/webtest/global/config/AsyncConfig.java
+++ b/src/main/java/com/test/webtest/global/config/AsyncConfig.java
@@ -1,0 +1,26 @@
+package com.test.webtest.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+/**
+ *  비동기 설정
+ */
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+    @Bean(name = "logicExecutor")
+    public Executor logicExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(4);
+        executor.setMaxPoolSize(16);
+        executor.setQueueCapacity(200);
+        executor.setThreadNamePrefix("logic-");
+        executor.initialize();
+        return executor;
+    }
+}


### PR DESCRIPTION
## 작업 개요
- status 로직 작성 및 score 로직 작성
- web, security 코드 작성
- shema.sql 코드 수정

## 주요 변경 사항
- status 폴더 안의 로직 작성
- score 폴더 안의 로직 작성
- security_vitals 코드 작성(entity, service, repository)
- web_vitals 코드 작성(entity, service, repository)
- schema.sql에 web_vitals 테이블 필드 수정
- score calculator 껍데기 코드 작성
- Async config 파일에 동기화 코드 작성

## 변경 파일
- /domain/logicstatus/*
- /domain/securityvitals/*
- /domain/webvitals/*
- /global/config/AsyncConfig
- /global/common/util/ScoreCalculator
- /resources/db/schema.sql
