### PR TITLE
refactor: send T2payload at logicStatus

### DIFF
--- a/src/main/java/com/test/webtest/WebtestApplication.java
+++ b/src/main/java/com/test/webtest/WebtestApplication.java
@@ -1,20 +1,33 @@
 package com.test.webtest;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
 import javax.sql.DataSource;
+import java.sql.SQLException;
 
 @SpringBootApplication
+@Slf4j
 public class WebtestApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(WebtestApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(WebtestApplication.class, args);
+    }
+
     @Bean
     ApplicationRunner printDs(DataSource ds) {
-        return args -> System.out.println("[DS] url = " + ds.getConnection().getMetaData().getURL());
+        return args -> {
+            // try-with-resources 사용으로 Connection 자동 반환
+            try (var connection = ds.getConnection()) {
+                String url = connection.getMetaData().getURL();
+                log.info("[DS] url = {}", url); // System.out.println 대신 로그 사용
+            } catch (SQLException e) {
+                log.error("[DS] 데이터소스 연결 실패", e);
+                throw new RuntimeException("데이터소스 연결 중 오류 발생", e);
+            }
+        };
     }
 }

--- a/src/main/java/com/test/webtest/domain/logicstatus/dto/T2Payload.java
+++ b/src/main/java/com/test/webtest/domain/logicstatus/dto/T2Payload.java
@@ -1,0 +1,20 @@
+package com.test.webtest.domain.logicstatus.dto;
+
+import com.test.webtest.domain.securityvitals.dto.SecurityVitalsView;
+import com.test.webtest.domain.webvitals.dto.WebVitalsView;
+
+public record T2Payload(
+        Scores scores,
+        SecurityVitalsView security,
+        WebVitalsView performance
+) {
+    public record Scores(
+            int total,
+            int lcpScore,
+            int clsScore,
+            int inpScore,
+            int fcpScore,
+            int tbtScore,
+            int ttfbScore
+    ) {}
+}

--- a/src/main/java/com/test/webtest/domain/logicstatus/service/LogicStatusServiceImpl.java
+++ b/src/main/java/com/test/webtest/domain/logicstatus/service/LogicStatusServiceImpl.java
@@ -1,12 +1,21 @@
 package com.test.webtest.domain.logicstatus.service;
 
 import com.test.webtest.domain.ai.service.AiRecommendationService;
+import com.test.webtest.domain.logicstatus.dto.T2Payload;
 import com.test.webtest.domain.logicstatus.repository.LogicStatusRepository;
-import com.test.webtest.domain.scores.service.ScoresService;
+import com.test.webtest.domain.scores.entity.ScoresEntity;
+import com.test.webtest.domain.scores.repository.ScoresRepository;
+import com.test.webtest.domain.securityvitals.repository.SecurityVitalsRepository;
+import com.test.webtest.domain.securityvitals.service.SecurityMessageService;
+import com.test.webtest.domain.webvitals.repository.WebVitalsRepository;
+import com.test.webtest.domain.webvitals.service.WebVitalsMessageService;
 import com.test.webtest.global.common.constants.Channel;
+import com.test.webtest.global.sse.SseEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.List;
 import java.util.UUID;
@@ -15,19 +24,57 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class LogicStatusServiceImpl {
     private final LogicStatusRepository repo;
-    private final ScoresService scoresService;
+    private final ScoresRepository scoresRepository;
+
+    private final SecurityVitalsRepository securityVitalsRepository;
+    private final WebVitalsRepository webVitalsRepository;
+
+    private final SecurityMessageService securityMessageService;
+    private final WebVitalsMessageService webVitalsMessageService;
+
+    private final com.test.webtest.domain.scores.service.ScoresService scoresService;
     private final AiRecommendationService aiService;
+    private final SseEventPublisher sse;
 
     @Transactional
     public void onPartialUpdate(UUID testId, Channel channel) {
-        switch(channel) {
-            case WEB -> repo.markWebReceived(testId);
+        switch (channel) {
+            case WEB      -> repo.markWebReceived(testId);
             case SECURITY -> repo.markSecReceived(testId);
         }
 
         // 점수 계산 (동기)
         boolean scoresMarked = markScoresReadyIfEligible(testId);
-        if (scoresMarked) scoresService.calcAndSave(testId);
+        if (scoresMarked) {
+            scoresService.calcAndSave(testId);
+            // 커밋 이후 t2 발행 (DB 반영 완료 보장)
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override public void afterCommit() {
+                    var secOpt = securityVitalsRepository.findByTest_Id(testId);
+                    var webOpt = webVitalsRepository.findByTest_Id(testId);
+                    var scOpt  = scoresRepository.findByTestId(testId);
+
+                    var secView = secOpt.map(securityMessageService::toView).orElse(null);
+                    var webView = webOpt.map(webVitalsMessageService::toView).orElse(null);
+
+                    int total   = scOpt.map(ScoresEntity::getTotal).orElse(0);
+                    int lcp     = scOpt.map(ScoresEntity::getLcpScore).orElse(0);
+                    int cls     = scOpt.map(ScoresEntity::getClsScore).orElse(0);
+                    int inp     = scOpt.map(ScoresEntity::getInpScore).orElse(0);
+                    int fcp     = scOpt.map(ScoresEntity::getFcpScore).orElse(0);
+                    int tbt     = scOpt.map(ScoresEntity::getTbtScore).orElse(0);
+                    int ttfb    = scOpt.map(ScoresEntity::getTtfbScore).orElse(0);
+
+                    var payload = new T2Payload(
+                            new T2Payload.Scores(total, lcp, cls, inp, fcp, tbt, ttfb),
+                            secView,
+                            webView
+                    );
+
+                    sse.publishTestPayload(testId.toString(), payload); // "t2"
+                }
+            });
+        }
 
         // Ai 호출 (비동기)
         boolean aiMarked = markAiTriggeredIfEligible(testId);

--- a/src/main/java/com/test/webtest/domain/securityvitals/service/SecurityVitalsServiceImpl.java
+++ b/src/main/java/com/test/webtest/domain/securityvitals/service/SecurityVitalsServiceImpl.java
@@ -79,16 +79,6 @@ public class SecurityVitalsServiceImpl implements SecurityVitalsService {
 
         // 5) 상태 플래그 업데이트 (같은 트랜잭션에서)
         logicStatusService.onPartialUpdate(testId, Channel.SECURITY);
-
-        // 6) 커밋 이후 SSE 전송
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override public void afterCommit() {
-                securityVitalsRepository.findByTest_Id(testId).ifPresent(entity -> {
-                    var view = messageService.toView(entity);
-                    sseEventPublisher.publishSecuritySnapshot(testId.toString(), view);
-                });
-            }
-        });
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/test/webtest/domain/test/service/TestServiceImpl.java
+++ b/src/main/java/com/test/webtest/domain/test/service/TestServiceImpl.java
@@ -47,7 +47,6 @@ public class TestServiceImpl implements TestService{
             @Override public void afterCommit() {
                 // 네트워크 호출이므로 트랜잭션 밖에서 실행
                 securityVitalsService.scanAndSave(testId);
-                // scanAndSave 내부에서 logicStatus 업데이트 & (선택) SSE 스냅샷 발송 수행
             }
         });
 

--- a/src/main/java/com/test/webtest/domain/webvitals/service/WebVitalsServiceImpl.java
+++ b/src/main/java/com/test/webtest/domain/webvitals/service/WebVitalsServiceImpl.java
@@ -44,16 +44,6 @@ public class WebVitalsServiceImpl implements WebVitalsService {
 
         // 같은 트랜잭션에서 상태 플래그 갱신
         logicStatusService.onPartialUpdate(testId, Channel.WEB);
-
-        // 커밋 이후 SSE로 즉시 스냅샷 전송
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override public void afterCommit() {
-                webVitalsRepository.findByTest_Id(testId).ifPresent(entity -> {
-                    var view = messageService.toView(entity);
-                    sseEventPublisher.publishWebSnapshot(testId.toString(), view);
-                });
-            }
-        });
     }
 
     @Override

--- a/src/main/java/com/test/webtest/global/sse/SseEmitterManager.java
+++ b/src/main/java/com/test/webtest/global/sse/SseEmitterManager.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import java.time.Duration;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Component
@@ -14,6 +15,7 @@ public class SseEmitterManager {
     private final Map<String, SseEmitter> emitterByTest = new ConcurrentHashMap<>();
 
     public SseEmitter register(String testId) {
+
         SseEmitter next = new SseEmitter(DEFAULT_TIMEOUT_MS);
         // 기존 연결이 있으면 정리 후 교체
         SseEmitter prev = emitterByTest.put(testId, next);

--- a/src/main/java/com/test/webtest/global/sse/SseEventController.java
+++ b/src/main/java/com/test/webtest/global/sse/SseEventController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.awt.*;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/tests")
@@ -14,13 +15,14 @@ public class SseEventController {
     private final SseEmitterManager manager;
     private final SseEventPublisher publisher;
 
-    @GetMapping(value = "/{id}/events", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter stream(@PathVariable("id") String testId) {
+    @GetMapping(value = "/{testId}/events", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter stream(@PathVariable UUID testId) {
         // 매니저에 등록
-        SseEmitter emitter = manager.register(testId);
+        String Id = String.valueOf(testId);
+        SseEmitter emitter = manager.register(Id);
 
         // ping 을 날려 읽기 활동을 만든다
-        publisher.ping(testId);
+        publisher.ping(Id);
 
         return emitter;
     }

--- a/src/main/java/com/test/webtest/global/sse/SseEventPublisher.java
+++ b/src/main/java/com/test/webtest/global/sse/SseEventPublisher.java
@@ -28,6 +28,10 @@ public class SseEventPublisher {
         manager.sendTo(testId, "t1_sec", dto);
     }
 
+    public void publishTestPayload(String testId, Object dto) {
+        manager.sendTo(testId, "t2", dto);
+    }
+
     public void publishAiAnalysisResult(String testId, Object dto) {
         manager.sendTo(testId, "t3_ai", dto);
     }


### PR DESCRIPTION
## 작업 개요
- t2payload를 logic status단에서 전송하도록 수정

## 주요 변경 사항
-  sse publisher에 t2payload 전달코드 추가
-  logic status t2payload dto 작성
-  logic status service에서 score, sec, web을 t2payload에 넣도록 수정

## 변경 파일
- /domain/logicstatus/dto/T2Payload
- /domain/logicstatus/service/LogicStatusServiceImpl
- /global/sse/SseEventPublisher
