### PR TITLE
refactor[#50]: Ai 예외 처리 코드 변경

### DIFF
--- a/src/main/java/com/test/webtest/domain/ai/service/AiRecommendationServiceImpl.java
+++ b/src/main/java/com/test/webtest/domain/ai/service/AiRecommendationServiceImpl.java
@@ -12,6 +12,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import java.util.*;
 
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import com.test.webtest.global.error.exception.AiCallFailedException;
 
 @Service
 @Slf4j
@@ -96,7 +97,7 @@ public class AiRecommendationServiceImpl implements AiRecommendationService {
 
         }catch(WebClientResponseException e){
             log.error("[GEMINI] status={} body={}", e.getStatusCode(), e.getResponseBodyAsString());
-            throw e;
+            throw new AiCallFailedException(e);
         }
     }
 

--- a/src/main/java/com/test/webtest/domain/ai/service/AiResponseParser.java
+++ b/src/main/java/com/test/webtest/domain/ai/service/AiResponseParser.java
@@ -2,6 +2,7 @@ package com.test.webtest.domain.ai.service;
 
 import com.test.webtest.domain.ai.AiSavePayload;
 import com.test.webtest.domain.ai.dto.AiResponse;
+import com.test.webtest.global.error.exception.AiParseFailedException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Component;
 
@@ -18,7 +19,7 @@ public class AiResponseParser {
         try {
             return objectMapper.readValue(response.getText(), AiSavePayload.class);
         } catch (Exception e) {
-            throw new IllegalStateException("AI JSON parse failed: " + response.getText(), e);
+            throw new AiParseFailedException(e);
         }
     }
 }

--- a/src/main/java/com/test/webtest/global/error/exception/AiCallFailedException.java
+++ b/src/main/java/com/test/webtest/global/error/exception/AiCallFailedException.java
@@ -5,4 +5,5 @@ import com.test.webtest.global.error.model.ErrorCode;
 public class AiCallFailedException extends BusinessException{
     public AiCallFailedException() { super(ErrorCode.AI_CALL_FAILED);}
     public AiCallFailedException(String msg) { super(ErrorCode.AI_CALL_FAILED, msg);}
+    public AiCallFailedException(Throwable cause) { super(ErrorCode.AI_CALL_FAILED, cause);}
 }

--- a/src/main/java/com/test/webtest/global/error/exception/AiParseFailedException.java
+++ b/src/main/java/com/test/webtest/global/error/exception/AiParseFailedException.java
@@ -1,0 +1,10 @@
+package com.test.webtest.global.error.exception;
+
+import com.test.webtest.global.error.model.ErrorCode;
+
+public class AiParseFailedException extends BusinessException{
+    public AiParseFailedException() { super(ErrorCode.AI_PARSE_FAILED);}
+    public AiParseFailedException(String msg) { super(ErrorCode.AI_PARSE_FAILED, msg);}
+    public AiParseFailedException(Throwable cause) { super(ErrorCode.AI_PARSE_FAILED, cause);}
+}
+

--- a/src/main/java/com/test/webtest/global/error/model/ErrorCode.java
+++ b/src/main/java/com/test/webtest/global/error/model/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
 
     // 외부 연동
     AI_CALL_FAILED           (HttpStatus.BAD_GATEWAY,            "AI_CALL_FAILED",           "AI 서버 호출에 실패했습니다."),
+    AI_PARSE_FAILED          (HttpStatus.INTERNAL_SERVER_ERROR,  "AI_PARSE_FAILED",          "AI 응답 파싱에 실패했습니다."),
     EXTERNAL_SERVICE_TIMEOUT (HttpStatus.GATEWAY_TIMEOUT,        "EXTERNAL_SERVICE_TIMEOUT", "외부 서비스 응답 지연으로 실패했습니다.");
 
     public final HttpStatus httpStatus;


### PR DESCRIPTION
## 작업 개요
AI 기능 예외 처리 코드 리팩토링

## 주요 변경 사항
- AiRocommendationServiceImpl에서 WebClientResponseException을 그대로 던지는 것을 AiCallFailedException을 던지도록 수정
- AiResponseParser에서 IllegalStateException을 던지는 것을 ai 답변 파싱에 대한 예외인 AiParseFailedException을 던지도록 변경

## 변경 파일
- src/main/java/com/test/webtest/domain/ai/service/AiRecommendationServiceImpl.java
- src/main/java/com/test/webtest/domain/ai/service/AiResponseParser.java
- src/main/java/com/test/webtest/global/error/exception/AiCallFailedException.java
- src/main/java/com/test/webtest/global/error/exception/AiParseFailedException.java
- src/main/java/com/test/webtest/global/error/model/ErrorCode.java