### PR TITLE
FIX[#77] cors 설정 새로운 도메인 허용하도록 변경

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,21 +1,29 @@
+# HTTP → HTTPS 리다이렉트
 server {
   listen 80;
+  server_name webanalyzer.site;
 
-  # 기본 프록시
+  location / {
+    return 301 https://$host$request_uri;
+  }
+}
+
+# HTTPS 서버
+server {
+  listen 443 ssl;
+  server_name webanalyzer.site;
+
+  ssl_certificate     /etc/letsencrypt/live/webanalyzer.site/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/webanalyzer.site/privkey.pem;
+
+  ssl_protocols TLSv1.2 TLSv1.3;
+  ssl_prefer_server_ciphers on;
+
   location / {
     proxy_pass http://app:8080;
     include /etc/nginx/snippets/proxy_headers.conf;
 
-    # 롱폴링(예: timeoutSec=60) 대비 - 60초보다 크게
     proxy_read_timeout 90s;
     proxy_send_timeout 90s;
   }
-
-  # (선택) /api만 별도 튜닝하고 싶으면 아래처럼 분리 가능
-  # location /api/ {
-  #   proxy_pass http://app:8080;
-  #   include /etc/nginx/snippets/proxy_headers.conf;
-  #   proxy_read_timeout 90s;
-  #   proxy_send_timeout 90s;
-  # }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -39,6 +39,7 @@ logging:
 web:
   cors:
     allowed-origins:
-      - "https://dashboard.webtest.com"
+      - "https://webanalyzer.site"
+      - "http://localhost:5173"
     allowed-extension-origins:
-      - "chrome-extension://<실제-확장-ID>"
+      - "chrome-extension://*"


### PR DESCRIPTION
## 작업 개요
> 새로 구입한 도메인 webanalyzer.site를 허용하도록 cors 변경 

## 상세 설명
- 새로 구입한 도메인 webanalyzer.site를 허용하도록 cors 변경 

## 공유할 사항
없슴다